### PR TITLE
Add Vivaldi to bypass mprotect

### DIFF
--- a/linux-mint_desktop/pax_flags_mint17.config
+++ b/linux-mint_desktop/pax_flags_mint17.config
@@ -6,5 +6,6 @@
 /usr/lib/firefox/plugin-container;m
 /usr/lib/thunderbird/thunderbird;m
 /usr/lib/chromium-browser/chromium-browser;m
+/opt/vivaldi/vivaldi-bin;m
 /usr/bin/amarok;m
 /usr/bin/pulseaudio;m


### PR DESCRIPTION
Vivaldi, a browser based on Chromium, was reported not to be working on a Grsec/PaX enabled machine.
As Chromium needs mprotect to be deactivated to be working, the user added `m   /opt/vivaldi/vivaldi-bin` to `/etc/paxd.conf` and that seemed to solve the issue.

So, I'm proposing here to add Vivaldi in the list of the default flags.
And, since I'm not familiar with Grsec and PaX, don't hesitate to point me in the direction of the other changes needed :)
